### PR TITLE
ci: add Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,88 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    name: Claude Code Review
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get PR diff
+        id: pr-diff
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            const diff = files.map(file => `${file.filename}\n${file.patch || ''}`).join('\n');
+            fs.writeFileSync('pr-diff.txt', diff);
+
+      - name: Send to Claude API
+        id: claude-review
+        env:
+          CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
+        run: |
+          curl -X POST https://api.anthropic.com/v1/messages \
+            -H "x-api-key: $CLAUDE_API_KEY" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "content-type: application/json" \
+            -d @- > claude-response.json << 'EOF'
+          {
+            "model": "claude-3-5-sonnet-20241022",
+            "max_tokens": 2048,
+            "messages": [
+              {
+                "role": "user",
+                "content": "You are a professional code reviewer. Please review the following pull request changes and provide constructive feedback. Focus on code quality, potential bugs, security concerns, and best practices.\n\nPR Diff:\n$(cat pr-diff.txt)"
+              }
+            ]
+          }
+          EOF
+
+      - name: Format review comment
+        id: format-comment
+        run: |
+          cat claude-response.json | jq -r '.content[0].text' > review-comment.md
+          echo "## 🤖 Claude Code Review" > claude-review-formatted.md
+          echo "" >> claude-review-formatted.md
+          cat review-comment.md >> claude-review-formatted.md
+
+      - name: Comment PR with review
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const reviewComment = fs.readFileSync('claude-review-formatted.md', 'utf8');
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: reviewComment
+            });


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs Claude-based automated review on pull requests (opened/synchronize/reopened) and posts the feedback as a PR comment.

## Test plan
- [x] Confirm `CLAUDE_API_KEY` secret is configured on the repository (or org) before merging, otherwise the review step will fail.
- [x] Open a test PR after merge and verify the workflow triggers and posts a review comment.